### PR TITLE
fixed bug where you cant send messages from frontend

### DIFF
--- a/chat_frontend/src/components/ChatDetails.svelte
+++ b/chat_frontend/src/components/ChatDetails.svelte
@@ -49,7 +49,7 @@
         <div class="error">{errorMessage}</div>
     {/if}
     <ul>
-        {#each messages as message (message.id) }
+        {#each messages as message (message.id)}
             <li>
                 {message.message}
                 <span>{new Date(message.createdAt).toLocaleTimeString()}</span>

--- a/src/controllers/main.ts
+++ b/src/controllers/main.ts
@@ -18,8 +18,8 @@ import {
 import {PrismaClient} from "@prisma/client";
 
 const corsOptions = {
-    origin: [Bun.env.CORS_ORIGIN as string],
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    origin: [Bun.env.CORS_ORIGIN as string, "localhost:3000", ],
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Authorization", "Content-Type"],
     maxAge: 86400,
 };

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -7,7 +7,8 @@ import {AUTH_PREFIX, LOGIN_ROUTE, REGISTER_ROUTE} from "../controllers/auth";
 
 export async function checkJWTAuth(c: Context, next: () => Promise<void>): Promise<Response | void> {
     if (c.req.path === API_PREFIX + AUTH_PREFIX + LOGIN_ROUTE ||
-        c.req.path === API_PREFIX + AUTH_PREFIX + REGISTER_ROUTE) {
+        c.req.path === API_PREFIX + AUTH_PREFIX + REGISTER_ROUTE ||
+        c.req.method === 'OPTIONS') {
         return await next();
     } else {
         const {JWT_SECRET} = env<{ JWT_SECRET: string }>(c);


### PR DESCRIPTION
Don't understand how this could have worked at all. 
OPTIONS was not allowed as a header and was not excluded from authentication checks. 

OPTIONs is now an allowed method and does not require a Bearer token to describe itself to clients